### PR TITLE
Fix logo and Dashai on the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h2 align="center">
 
 <br>
-<a href="www.dashai.org"><img src="/docs/images/dashai.png" alt="dashai.org" width="500"></a>
+[![dashai](docs/images/dashai.png)](http://www.dashai.org)
 <br>
 <br>
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
-# Dashai Deployment and Configuration Documentation
+# dashai Deployment and Configuration Documentation
 
 [![forthebadge](http://forthebadge.com/images/badges/built-with-love.svg)](https://github.com/ArctiqTeam)
 
 <h2 align="center">
 
 <br>
+
 [![dashai](docs/images/dashai.png)](http://www.dashai.org)
+
 <br>
+
 <br>
 
 </h2>


### PR DESCRIPTION
# Summary

Not sure why previous conflicts weren't resolved before merging:

### Fix broken link for dashai logo

<img width="1280" alt="screen shot 2018-05-08 at 9 31 41 am" src="https://user-images.githubusercontent.com/13129393/39770001-a9c2416e-52a2-11e8-91d0-25f2b6eb4b94.png">

### Fix Dashai -> dashai

